### PR TITLE
Only symlink if the `LUA_INCDIR` is writable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,5 @@ install: $(SOBJ)
 	$(INSTALL) $(SOBJ) $(INST_LIBDIR)
 	$(INSTALL) src/lauxhlib.h $(CONFDIR)
 	rm -f $(LUA_INCDIR)/lauxhlib.h
-	ln -s $(CONFDIR)/lauxhlib.h $(LUA_INCDIR)
+	-[ -w $(LUA_INCDIR) ] && ln -s $(CONFDIR)/lauxhlib.h $(LUA_INCDIR)
 	rm -f $(SOBJ) $(GCDAS)


### PR DESCRIPTION
Symlinking `lauxhlib.h` in Linux distros that have read-only filesystem (such as NixOS) will fail
```
[...]
rm -f /nix/store/60djkmpzmyv5r2w77p855b58mpgxc1cm-lua-5.4.6/include/lauxhlib.h
ln -s /home/komo/Projects/null/lua_modules/lib/luarocks/rocks-5.4/lauxhlib/0.6.1-1/conf/lauxhlib.h /nix/store/60djkmpzmyv5r2w77p855b58mpgxc1cm-lua-5.4.6/include
ln: failed to create symbolic link '/nix/store/60djkmpzmyv5r2w77p855b58mpgxc1cm-lua-5.4.6/include/lauxhlib.h': Read-only file system
make: *** [Makefile:29: install] Error 1
[...]
```